### PR TITLE
fix: correct cloudflare caching logic

### DIFF
--- a/src/middleware/_tests_/cloudflareCache.test.ts
+++ b/src/middleware/_tests_/cloudflareCache.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cloudflareCache } from '../cloudflareCache.ts';
+
+describe('cloudflareCache middleware', () => {
+  it('returns cached response for GET requests', async () => {
+    const cachedResponse = new Response('cached', {
+      headers: { 'x-test': '1' },
+    });
+    const match = vi.fn().mockResolvedValue(cachedResponse);
+    const put = vi.fn();
+    const next = vi.fn();
+
+    const ctx = {
+      request: new Request('https://example.com', { method: 'GET' }),
+      locals: { runtime: { caches: { default: { match, put } } } },
+    } as any;
+
+    const response = await cloudflareCache(ctx, next);
+
+    expect(match).toHaveBeenCalledOnce();
+    expect(next).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+    if (!response) throw new Error('Response is undefined');
+    expect(await response.text()).toBe('cached');
+    expect(response.headers.get('x-test')).toBe('1');
+  });
+
+  it('bypasses cache for non-GET requests', async () => {
+    const match = vi.fn();
+    const put = vi.fn();
+    const next = vi.fn().mockResolvedValue(new Response('fresh'));
+
+    const ctx = {
+      request: new Request('https://example.com', { method: 'POST' }),
+      locals: { runtime: { caches: { default: { match, put } } } },
+    } as any;
+
+    const response = await cloudflareCache(ctx, next);
+
+    expect(match).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledOnce();
+    if (!response) throw new Error('Response is undefined');
+    expect(await response.text()).toBe('fresh');
+  });
+});

--- a/src/middleware/cloudflareCache.ts
+++ b/src/middleware/cloudflareCache.ts
@@ -1,15 +1,20 @@
 import { defineMiddleware } from 'astro:middleware';
 
 export const cloudflareCache = defineMiddleware(async (ctx, next) => {
-  const request = ctx.request;
-  const cache = ctx.locals.runtime.caches.default;
+  const { request, locals } = ctx;
+
+  // Only cache GET requests. Other methods are not cacheable and may cause
+  // unexpected behaviour if cached.
+  if (request.method !== 'GET') return next();
+
+  const cache = locals.runtime.caches.default;
   const requestUrl = new URL(request.url);
   // biome-ignore lint/suspicious/noExplicitAny: Astro and Cloudflare types are not compatible
   const cacheKey = new Request(requestUrl.toString(), request as any) as any;
 
-  // If the request is cached, return the cached response
+  // If the request is cached, return it directly
   const cachedResponse = (await cache.match(cacheKey)) as Response | undefined;
-  if (cachedResponse) return new Response(cachedResponse.body, cachedResponse);
+  if (cachedResponse) return cachedResponse;
 
   // If the request is not cached, fetch the response and cache it
   // biome-ignore lint/suspicious/noExplicitAny: Astro and Cloudflare types are not compatible


### PR DESCRIPTION
## Summary
- avoid caching non-GET requests and return cached responses directly
- add tests for cloudflare cache middleware

## Testing
- `pnpm exec vitest run`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68950f6433d08323a9f27b0843dffd0c